### PR TITLE
WMTS-tile fetching during animated zoom in Leaflet

### DIFF
--- a/examples/leaflet/example1.js
+++ b/examples/leaflet/example1.js
@@ -36,7 +36,7 @@
         attribution: myAttributionText,
         crossOrigin: true,
         zoom: function () {
-            var zoomlevel = map.getZoom();
+            var zoomlevel = map._animateToZoom ? map._animateToZoom : map.getZoom();
             console.log("WMTS: " + zoomlevel);
             if (zoomlevel < 10)
                 return 'L0' + zoomlevel;


### PR DESCRIPTION
When map.zoomAnimation = true (default), map.getZoom() returns the "previous" zoom level during the approx. first half of the animation, causing a mismatch between TileMatrix, TileRow and TileColumn in the query. 

During an animated zoom, the map. _animateToZoom property contains the correct zoom level (it is undefined when not zooming).