### PR TITLE
Workaround for white stripes between Leaflet tiles in Chrome

### DIFF
--- a/examples/leaflet/example1.js
+++ b/examples/leaflet/example1.js
@@ -1,13 +1,28 @@
 (function() {
-    
+
+    //  Workaround for 1px lines appearing in some browsers due to fractional transforms
+    //  and resulting anti-aliasing.
+    //  https://github.com/Leaflet/Leaflet/issues/3575
+    if (window.navigator.userAgent.indexOf('Chrome') > -1) {
+        var originalInitTile = L.GridLayer.prototype._initTile;
+        L.GridLayer.include({
+            _initTile: function (tile) {
+                originalInitTile.call(this, tile);
+                var tileSize = this.getTileSize();
+                tile.style.width = tileSize.x + 1 + 'px';
+                tile.style.height = tileSize.y + 1 + 'px';
+            }
+        });
+    }
+
     // Set Kortforsyningen token, replace with your own token
     var kftoken = 'd12107f70a3ee93153f313c7c502169a';
 
     // Set the attribution (the copyright statement shown in the lower right corner)
     // We do this as we want the same attributions for all layers
     var myAttributionText = '&copy; <a target="_blank" href="https://download.kortforsyningen.dk/content/vilk%C3%A5r-og-betingelser">Styrelsen for Dataforsyning og Effektivisering</a>';
- 
- 
+
+
     // Make the map object using the custom projection
     //proj4.defs('EPSG:25832', "+proj=utm +zone=32 +ellps=GRS80 +units=m +no_defs");
     var crs = new L.Proj.CRS('EPSG:25832',
@@ -43,8 +58,8 @@
                 return 'L' + zoomlevel;
         }
     }).addTo(map);
-    
-    
+
+
     // Skærmkort [WMTS:topo_skaermkort]
     var toposkaermkortwmts = L.tileLayer.wms('https://services.kortforsyningen.dk/topo_skaermkort', {
         layers: 'dtk_skaermkort',
@@ -52,7 +67,7 @@
         format: 'image/png',
         attribution: myAttributionText
     });
-    
+
     // Matrikelskel overlay [WMS:mat]
     var matrikel = L.tileLayer.wms('https://services.kortforsyningen.dk/mat', {
         transparent: true,
@@ -85,9 +100,9 @@
     };
 
     // Add layer control to map
-    L.control.layers(baseLayers, overlays).addTo(map);    
+    L.control.layers(baseLayers, overlays).addTo(map);
 
     // Add scale line to map
     L.control.scale({imperial: false}).addTo(map); // disable feet units
 
-})();    
+})();


### PR DESCRIPTION
Workaround for issue that seems to be connected to https://github.com/Leaflet/Leaflet/issues/3575.

White stripes appearing between tiles in Chrome/Chromium:
<img width="681" alt="screen shot 2018-05-18 at 10 58 52" src="https://user-images.githubusercontent.com/1301881/40228317-3d49987e-5a91-11e8-9f69-037d573559fb.png">

After the workaround has been applied:
<img width="736" alt="screen shot 2018-05-18 at 11 06 03" src="https://user-images.githubusercontent.com/1301881/40228304-312e3acc-5a91-11e8-95fe-82abba6824c0.png">

The workaround involves scaling tiles by 1px in both x- and y-direction, thus making tiles slightly less sharp.